### PR TITLE
fixup! Use retry decorator from tenacity for retry logic

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,5 +11,5 @@ paramiko>=2.1.6,<2.2
 python-heatclient>=1.6.1,<1.7
 python-keystoneclient>=3.17.0,<3.18
 python-novaclient>=7.1.2,<7.2
-tenacity<6.2.0
+tenacity>=6.2
 -e .

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'python-heatclient',
         'python-keystoneclient',
         'python-novaclient',
+        'tenacity',
     ],
     entry_points={
         'xblock.v1': [


### PR DESCRIPTION
Small suggested fixup.

Swaps the order of connection closure and logging: close connection immediately after failure, then log that we're going to retry.

Requires tenacity 6.2.0 because of https://github.com/jd/tenacity/commit/c5a8abb404c50bddd9881c69b995c343ab7b4991