### PR TITLE
Run tox via GitHub Actions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,22 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,13 @@ python =
   3.7: py37,flake8
   3.8: py38,flake8
 
+[gh-actions]
+python =
+    3.5: py35,flake8
+    3.6: py36,flake8
+    3.7: py37,flake8
+    3.8: py38,flake8
+
 [flake8]
 ignore = E124,W504
 exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,src


### PR DESCRIPTION
Use the tox-gh-actions plugin to run tox from GitHub Actions.