### PR TITLE
squash! Add support for Python 3.12

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,11 +14,13 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
-          - '3.12'
         pip-version:
-          # - 22.0.4
-          # - 23.0.1
+          - 22.0.4
+          - 23.0.1
           - 23.2.1
+        include:
+          - python-version: '3.12'
+            pip-version: '23.2.1'
 
     steps:
     - name: Check out code


### PR DESCRIPTION
Also, update the GitHub Actions workflow matrix so that we test all supported pip versions with Python 3.8–3.11, but only pip 23 on Python 3.12.