### PR TITLE
build: Use generative section names in tox.ini

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec tox -e flake8
+exec tox -e py311-flake8,py312-flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = flake8,pipdeptree{,-requirements},py{311,312}-xblock40-celery5
+envlist = py{311,312}-{flake8,pipdeptree,pipdeptree-requirements,xblock40-celery5}
 
 [gh-actions]
 python =
-    3.11: flake8,pipdeptree,pipdeptree-requirements,py311
-    3.12: flake8,pipdeptree,pipdeptree-requirements,py312
+    3.11: py311-{flake8,pipdeptree,pipdeptree-requirements,xblock40-celery5}
+    3.12: py312-{flake8,pipdeptree,pipdeptree-requirements,xblock40-celery5}
 
 [flake8]
 ignore = E124,W504
@@ -31,21 +31,18 @@ deps =
 commands =
     python run_tests.py []
 
-[testenv:pipdeptree]
-basepython = python3.11
+[testenv:py{311,312}-pipdeptree]
 deps =
     pipdeptree
 commands = pipdeptree -w fail
 
-[testenv:pipdeptree-requirements]
-basepython = python3.11
+[testenv:py{311,312}-pipdeptree-requirements]
 deps =
     -rrequirements.txt
     pipdeptree
 commands = pipdeptree -w fail
 
-[testenv:flake8]
-basepython = python3.11
+[testenv:py{311,312}-flake8]
 skip_install = True
 deps =
     -rrequirements/flake8.txt


### PR DESCRIPTION
By prefixing *all* our testenvs with the Python version factor ("py311", "py312", etc.), we can ensure that all of our testenvs can be invoked with either Python version being present on the system.

tox will then skip those environments that don't match the Python present on the system, and — provided the remaining environments succeed — return with zero exit code (indicating success).

However, if *all* environments are skipped, because there is no matching Python version present on the system at all, it returns with a nonzero exit code (indicating failure).

Reference:
https://tox.wiki/en/latest/config.html#generative-section-names